### PR TITLE
Bumps default version of chocolatey

### DIFF
--- a/flavor_cookbooks/pan_base/templates/default/metadata.rb.erb
+++ b/flavor_cookbooks/pan_base/templates/default/metadata.rb.erb
@@ -7,4 +7,4 @@ version '0.1.0'
 
 depends 'chef-client', '4.3.0'
 depends 'omnibus_updater', '1.0.4'
-depends 'chocolatey', '0.3.1'
+depends 'chocolatey', '1.0.0'


### PR DESCRIPTION
Chocolatey now has version 1.0.0. 
It fixes a bug where your chef cookbooks would break when chocolatey is down.
